### PR TITLE
Normalize Azurerm class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here's an example ```.kitchen.yml``` file that provisions 3 different types of U
 ```yml
 ---
 driver:
-  name: AzureRM
+  name: azurerm
 
 driver_config:
   subscription_id: '4801fa9d-YOUR-GUID-HERE-b265ff49ce21'
@@ -87,7 +87,7 @@ Here's a further example ```.kitchen.yml``` file that will provision a Windows S
 ```yml
 ---
 driver:
-  name: AzureRM
+  name: azurerm
 
 driver_config:
   subscription_id: '4801fa9d-YOUR-GUID-HERE-b265ff49ce21'

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -7,9 +7,9 @@ require 'azure_mgmt_network'
 module Kitchen
   module Driver
     #
-    # AzureRM
+    # Azurerm
     #
-    class AzureRM < Kitchen::Driver::Base
+    class Azurerm < Kitchen::Driver::Base
       attr_accessor :resource_management_client
 
       default_config(:azure_resource_group_name) do |config|

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -16,7 +16,7 @@ module Kitchen
         if File.file?(config_file)
           @credentials = IniFile.load(File.expand_path(config_file))
         else
-          Chef::Log.warn "#{CONFIG_PATH} was not found or not accessible." unless File.file?(config_file)
+          warn "#{CONFIG_PATH} was not found or not accessible."
         end
       end
 


### PR DESCRIPTION
When test-kitchen loads a driver, it looks for a file with the name specified in ```.kitchen.yml```. Because the class's name has uppercase characters in it, the same casing has to be used in the config. This is fine on Windows because filenames are case-insensitive. However, on Linux, test-kitchen tries to require ```kitchen/driver/AzureRM``` which is different from ```kitchen/driver/azurerm```.

This could be solved either by renaming the ```azurerm.rb``` to ```AzureRM.rb``` or by changing the class name to have only the first letter capitalized. I feel the latter is more how the test-kitchen folks intended it to work, which is what this pull request changes.

Additionally, I stumbled on a problem with the credentials class trying to use Chef::Log to log a warning, which isn't loaded as part of test-kitchen.

Coincidentally, this still fails to run on Linux, but it's not this gem's fault. The ```azure_mgmt_resources``` gem had a similar problem with casing that's been fixed, but hasn't been uploaded to rubygems yet.