### PR TITLE
provide vm_name option for naming the vm inside of the resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ platforms:
   - name: ubuntu-14.04
     driver_config:
       image_urn: Canonical:UbuntuServer:14.04.3-LTS:latest
+      vm_name: trusty-vm
   - name: ubuntu-15.04
     driver_config:
       image_urn: Canonical:UbuntuServer:15.04:latest


### PR DESCRIPTION
The way this appears in the UI could be a bit confusing to users. 

While the resource groups are unique there are just a bunch of vms named 'vm', this pr allows the value to be set if desired.