### PR TITLE
Update driver to include tag parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ info:    vm image list command OK
 - Note that the ```driver_config``` section also takes a ```username``` and ```password``` parameter, the defaults if these are not specified are "azure" and "P2ssw0rd" respectively.
 - The ```storage_account_type``` parameter defaults to 'Standard_LRS' and allows you to switch to premium storage (e.g. 'Premium_LRS')
 - The ```enable_boot_diagnostics``` parameter defaults to 'true' and allows you to switch off boot diagnostics in case you are using premium storage.
+- The optional ```vm_tags``` parameter allows you to define key:value pairs to tag VMs with on creation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ platforms:
     driver_config:
       image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
       vm_name: trusty-vm
+      vm_tags:
+        ostype: linux
+        distro: ubuntu
 
 suites:
   - name: default

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -240,7 +240,7 @@ module Kitchen
 
       def vm_tag_string(vm_tags_in)
         tag_string = ''
-        if !vm_tags_in.empty?
+        unless vm_tags_in.empty?
           tag_array = vm_tags_in.map do |key, value|
             "\"#{key}\": \"#{value}\",\n"
           end

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -67,6 +67,10 @@ module Kitchen
         {}
       end
 
+      default_config(:vm_tags) do |_config|
+        {}
+      end
+
       def create(state)
         state = validate_state(state)
         image_publisher, image_offer, image_sku, image_version = config[:image_urn].split(':', 4)
@@ -234,6 +238,19 @@ module Kitchen
         deployment
       end
 
+      def vm_tag_string(vm_tags_in)
+        tag_string = ''
+        if !vm_tags_in.empty?
+          tag_array = vm_tags_in.map do |key, value|
+            "\"#{key}\": \"#{value}\",\n"
+          end
+          # Strip punctuation from last item
+          tag_array[-1] = tag_array[-1][0..-3]
+          tag_string = tag_array.join
+        end
+        tag_string
+      end
+
       def parameters_in_values_format(parameters_in)
         parameters = parameters_in.map do |key, value|
           { key.to_sym => { 'value' => value } }
@@ -358,14 +375,14 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
 
       def virtual_machine_deployment_template
         if config[:vnet_id] == ''
-          virtual_machine_deployment_template_public
+          virtual_machine_deployment_template_public(vm_tag_string(config[:vm_tags]))
         else
           info "Using custom vnet: #{config[:vnet_id]}"
-          virtual_machine_deployment_template_internal(config[:vnet_id], config[:subnet_id])
+          virtual_machine_deployment_template_internal(config[:vnet_id], config[:subnet_id], vm_tag_string(config[:vm_tags]))
         end
       end
 
-      def virtual_machine_deployment_template_internal(vnet_id, subnet_id)
+      def virtual_machine_deployment_template_internal(vnet_id, subnet_id, vm_tag_string)
         <<-EOH
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -550,6 +567,9 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
                         "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
                     }
                 }
+            },
+            "tags": {
+                #{vm_tag_string}
             }
         }
     ]
@@ -557,7 +577,7 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
         EOH
       end
 
-      def virtual_machine_deployment_template_public
+      def virtual_machine_deployment_template_public(vm_tag_string)
         <<-EOH
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -782,6 +802,9 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
                         "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
                     }
                 }
+            },
+            "tags": {
+                #{vm_tag_string}
             }
         }
     ]


### PR DESCRIPTION
Working with dynamic inventories for Ansible etc is made easier by using VM tags, these changes allow you define tags as part of the driver config that are applied to the VMs at build time.