### PR TITLE
Public IP support for existing vnet deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Example predeploy.json:
 The following example introduces the ```vnet_id``` and ```subnet_id``` properties under driver_config in the configuration file.  This can be applied at the top level, or per platform.
 You can use this capability to create the VM on an existing virtual network and subnet created in a different resource group.
 
-In this case, the public IP address is not used.
+In this case, the public IP address is not used unless ```public_ip``` is set to ```true```
 
 
 ```yaml

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/pendrica/kitchen-azurerm'
   spec.license       = 'Apache-2.0'
 
-  spec.files         = Dir['LICENSE', 'README.md', 'CHANGELOG.md', 'lib/**/*']
+  spec.files         = Dir['LICENSE', 'README.md', 'CHANGELOG.md', 'lib/**/*', 'templates/**/*']
   spec.require_paths = ['lib']
 
   spec.add_dependency 'inifile', '~> 3.0', '>= 3.0.0'

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -380,15 +380,10 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
 
       def virtual_machine_deployment_template
         if config[:vnet_id] == ''
-          virtual_machine_deployment_template_file('public.erb', vm_tag_string: config[:vm_tags])
+          virtual_machine_deployment_template_file('public.erb', vm_tags: vm_tag_string(config[:vm_tags]))
         else
           info "Using custom vnet: #{config[:vnet_id]}"
-          virtual_machine_deployment_template_file('internal.erb',
-                                                    vnet_id: config[:vnet_id],
-                                                    subnet_id: config[:subnet_id],
-                                                    public_ip: config[:public_ip],
-                                                    vm_tag_string: config[:vm_tags]
-                                                  )
+          virtual_machine_deployment_template_file('internal.erb', vnet_id: config[:vnet_id], subnet_id: config[:subnet_id], public_ip: config[:public_ip], vm_tags: vm_tag_string(config[:vm_tags]))
         end
       end
 

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -6,6 +6,7 @@ require 'azure_mgmt_network'
 require 'base64'
 require 'sshkey'
 require 'fileutils'
+require 'erb'
 
 module Kitchen
   module Driver
@@ -71,6 +72,10 @@ module Kitchen
         {}
       end
 
+      default_config(:public_ip) do |_config|
+        false
+      end
+
       def create(state)
         state = validate_state(state)
         image_publisher, image_offer, image_sku, image_version = config[:image_urn].split(':', 4)
@@ -131,7 +136,7 @@ module Kitchen
         # Monitor all operations until completion
         follow_deployment_until_end_state(state[:azure_resource_group_name], deployment_name)
 
-        if config[:vnet_id] == ''
+        if config[:vnet_id] == '' || config[:public_ip]
           # Retrieve the public IP from the resource group:
           network_management_client = ::Azure::ARM::Network::NetworkManagementClient.new(credentials)
           network_management_client.subscription_id = config[:subscription_id]
@@ -375,441 +380,23 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
 
       def virtual_machine_deployment_template
         if config[:vnet_id] == ''
-          virtual_machine_deployment_template_public(vm_tag_string(config[:vm_tags]))
+          virtual_machine_deployment_template_file('public.erb', vm_tag_string: config[:vm_tags])
         else
           info "Using custom vnet: #{config[:vnet_id]}"
-          virtual_machine_deployment_template_internal(config[:vnet_id], config[:subnet_id], vm_tag_string(config[:vm_tags]))
+          virtual_machine_deployment_template_file('internal.erb',
+                                                    vnet_id: config[:vnet_id],
+                                                    subnet_id: config[:subnet_id],
+                                                    public_ip: config[:public_ip],
+                                                    vm_tag_string: config[:vm_tags]
+                                                  )
         end
       end
 
-      def virtual_machine_deployment_template_internal(vnet_id, subnet_id, vm_tag_string)
-        <<-EOH
-{
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "The location where the resources will be created."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "metadata": {
-                "description": "The size of the VM to be created"
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "User name for the Virtual Machine."
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
-        "dnsNameForPublicIP": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        "imagePublisher": {
-            "type": "string",
-            "defaultValue": "Canonical",
-            "metadata": {
-                "description": "Publisher for the VM, e.g. Canonical, MicrosoftWindowsServer"
-            }
-        },
-        "imageOffer": {
-            "type": "string",
-            "defaultValue": "UbuntuServer",
-            "metadata": {
-                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
-            }
-        },
-        "imageSku": {
-            "type": "string",
-            "defaultValue": "14.04.3-LTS",
-            "metadata": {
-                "description": "Sku for the VM, e.g. 14.04.3-LTS"
-            }
-        },
-        "imageVersion": {
-            "type": "string",
-            "defaultValue": "latest",
-            "metadata": {
-                "description": "Either a date or latest."
-            }
-        },
-        "vmName": {
-            "type": "string",
-            "defaultValue": "vm",
-            "metadata": {
-                "description": "The vm name created inside of the resource group."
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "metadata": {
-                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
-            }
-        },
-        "bootDiagnosticsEnabled": {
-            "type": "string",
-            "defaultValue": "true",
-            "metadata": {
-                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage)."
-            }
-        }
-    },
-    "variables": {
-        "location": "[parameters('location')]",
-        "OSDiskName": "osdisk",
-        "nicName": "nic",
-        "addressPrefix": "10.0.0.0/16",
-        "subnetName": "#{subnet_id}",
-        "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "[parameters('storageAccountType')]",
-        "publicIPAddressName": "publicip",
-        "publicIPAddressType": "Dynamic",
-        "vmStorageAccountContainerName": "vhds",
-        "vmName": "[parameters('vmName')]",
-        "vmSize": "[parameters('vmSize')]",
-        "virtualNetworkName": "vnet",
-        "vnetID": "#{vnet_id}",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
-            "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('storageAccountType')]"
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('nicName')]",
-            "location": "[variables('location')]",
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[variables('vmName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[variables('vmSize')]"
-                },
-                "osProfile": {
-                    "computername": "[variables('vmName')]",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[parameters('imagePublisher')]",
-                        "offer": "[parameters('imageOffer')]",
-                        "sku": "[parameters('imageSku')]",
-                        "version": "[parameters('imageVersion')]"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
-                    }
-                }
-            },
-            "tags": {
-                #{vm_tag_string}
-            }
-        }
-    ]
-}
-        EOH
-      end
-
-      def virtual_machine_deployment_template_public(vm_tag_string)
-        <<-EOH
-{
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "The location where the resources will be created."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "metadata": {
-                "description": "The size of the VM to be created"
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "User name for the Virtual Machine."
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
-        "dnsNameForPublicIP": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        "imagePublisher": {
-            "type": "string",
-            "defaultValue": "Canonical",
-            "metadata": {
-                "description": "Publisher for the VM, e.g. Canonical, MicrosoftWindowsServer"
-            }
-        },
-        "imageOffer": {
-            "type": "string",
-            "defaultValue": "UbuntuServer",
-            "metadata": {
-                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
-            }
-        },
-        "imageSku": {
-            "type": "string",
-            "defaultValue": "14.04.3-LTS",
-            "metadata": {
-                "description": "Sku for the VM, e.g. 14.04.3-LTS"
-            }
-        },
-        "imageVersion": {
-            "type": "string",
-            "defaultValue": "latest",
-            "metadata": {
-                "description": "Either a date or latest."
-            }
-        },
-        "vmName": {
-            "type": "string",
-            "defaultValue": "vm",
-            "metadata": {
-                "description": "The vm name created inside of the resource group."
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "metadata": {
-                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
-            }
-        },
-        "bootDiagnosticsEnabled": {
-            "type": "string",
-            "defaultValue": "true",
-            "metadata": {
-                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage)."
-            }
-        }
-    },
-    "variables": {
-        "location": "[parameters('location')]",
-        "OSDiskName": "osdisk",
-        "nicName": "nic",
-        "addressPrefix": "10.0.0.0/16",
-        "subnetName": "Subnet",
-        "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "[parameters('storageAccountType')]",
-        "publicIPAddressName": "publicip",
-        "publicIPAddressType": "Dynamic",
-        "vmStorageAccountContainerName": "vhds",
-        "vmName": "[parameters('vmName')]",
-        "vmSize": "[parameters('vmSize')]",
-        "virtualNetworkName": "vnet",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
-            "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('storageAccountType')]"
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[variables('location')]",
-            "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
-                }
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[variables('location')]",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('addressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "[variables('subnetPrefix')]"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('nicName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[variables('vmName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[variables('vmSize')]"
-                },
-                "osProfile": {
-                    "computername": "[variables('vmName')]",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[parameters('imagePublisher')]",
-                        "offer": "[parameters('imageOffer')]",
-                        "sku": "[parameters('imageSku')]",
-                        "version": "[parameters('imageVersion')]"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
-                    }
-                }
-            },
-            "tags": {
-                #{vm_tag_string}
-            }
-        }
-    ]
-}
-        EOH
+      def virtual_machine_deployment_template_file(template_file, data = {})
+        template = File.read(File.expand_path(File.join(__dir__, '../../../templates', template_file)))
+        render_binding = binding
+        data.each { |key, value| render_binding.local_variable_set(key.to_sym, value) }
+        ERB.new(template, nil, '-').result(render_binding)
       end
     end
   end

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -205,7 +205,7 @@
                 }
             },
             "tags": {
-                <%= vm_tag_string %>
+                <%= vm_tags %>
             }
         }
     ]

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "The location where the resources will be created."
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "metadata": {
+                "description": "The size of the VM to be created"
+            }
+        },
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for the Virtual Machine."
+            }
+        },
+        "dnsNameForPublicIP": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "imagePublisher": {
+            "type": "string",
+            "defaultValue": "Canonical",
+            "metadata": {
+                "description": "Publisher for the VM, e.g. Canonical, MicrosoftWindowsServer"
+            }
+        },
+        "imageOffer": {
+            "type": "string",
+            "defaultValue": "UbuntuServer",
+            "metadata": {
+                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
+            }
+        },
+        "imageSku": {
+            "type": "string",
+            "defaultValue": "14.04.3-LTS",
+            "metadata": {
+                "description": "Sku for the VM, e.g. 14.04.3-LTS"
+            }
+        },
+        "imageVersion": {
+            "type": "string",
+            "defaultValue": "latest",
+            "metadata": {
+                "description": "Either a date or latest."
+            }
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "vm",
+            "metadata": {
+                "description": "The vm name created inside of the resource group."
+            }
+        },
+        "storageAccountType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "metadata": {
+                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
+            }
+        },
+        "bootDiagnosticsEnabled": {
+            "type": "string",
+            "defaultValue": "true",
+            "metadata": {
+                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage)."
+            }
+        }
+    },
+    "variables": {
+        "location": "[parameters('location')]",
+        "OSDiskName": "osdisk",
+        "nicName": "nic",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "<%= subnet_id %>",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "[parameters('storageAccountType')]",
+        "publicIPAddressName": "publicip",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "[parameters('vmName')]",
+        "vmSize": "[parameters('vmSize')]",
+        "virtualNetworkName": "vnet",
+        "vnetID": "<%= vnet_id %>",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        <%- if public_ip -%>
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+                }
+            }
+        },
+        <%- end -%>
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            <%- if public_ip -%>
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            <%- end -%>
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[parameters('imagePublisher')]",
+                        "offer": "[parameters('imageOffer')]",
+                        "sku": "[parameters('imageSku')]",
+                        "version": "[parameters('imageVersion')]"
+                    },
+                    "osDisk": {
+                        "name": "osdisk",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
+                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
+                    }
+                }
+            },
+            "tags": {
+                <%= vm_tag_string %>
+            }
+        }
+    ]
+}

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -223,7 +223,7 @@
                 }
             },
             "tags": {
-                <%= vm_tag_string %>
+                <%= vm_tags %>
             }
         }
     ]

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -1,0 +1,230 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "The location where the resources will be created."
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "metadata": {
+                "description": "The size of the VM to be created"
+            }
+        },
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for the Virtual Machine."
+            }
+        },
+        "dnsNameForPublicIP": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "imagePublisher": {
+            "type": "string",
+            "defaultValue": "Canonical",
+            "metadata": {
+                "description": "Publisher for the VM, e.g. Canonical, MicrosoftWindowsServer"
+            }
+        },
+        "imageOffer": {
+            "type": "string",
+            "defaultValue": "UbuntuServer",
+            "metadata": {
+                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
+            }
+        },
+        "imageSku": {
+            "type": "string",
+            "defaultValue": "14.04.3-LTS",
+            "metadata": {
+                "description": "Sku for the VM, e.g. 14.04.3-LTS"
+            }
+        },
+        "imageVersion": {
+            "type": "string",
+            "defaultValue": "latest",
+            "metadata": {
+                "description": "Either a date or latest."
+            }
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "vm",
+            "metadata": {
+                "description": "The vm name created inside of the resource group."
+            }
+        },
+        "storageAccountType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "metadata": {
+                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
+            }
+        },
+        "bootDiagnosticsEnabled": {
+            "type": "string",
+            "defaultValue": "true",
+            "metadata": {
+                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage)."
+            }
+        }
+    },
+    "variables": {
+        "location": "[parameters('location')]",
+        "OSDiskName": "osdisk",
+        "nicName": "nic",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "Subnet",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "[parameters('storageAccountType')]",
+        "publicIPAddressName": "publicip",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "[parameters('vmName')]",
+        "vmSize": "[parameters('vmSize')]",
+        "virtualNetworkName": "vnet",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[parameters('imagePublisher')]",
+                        "offer": "[parameters('imageOffer')]",
+                        "sku": "[parameters('imageSku')]",
+                        "version": "[parameters('imageVersion')]"
+                    },
+                    "osDisk": {
+                        "name": "osdisk",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
+                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
+                    }
+                }
+            },
+            "tags": {
+                <%= vm_tag_string %>
+            }
+        }
+    ]
+}


### PR DESCRIPTION
While using this driver I ran into the scenario that I would like to provision my VM using Kitchen in an existing VNET on Azure. However the VM in the VNET is accessible from my local network because there is no gateway in between. There for I would like the possibility to expose a public IP when the VNET is specified.

**Implementation details**
- Config parameter `public_ip`
- Using ERB for rendering the ARM template to have better support for conditions inside the template.
- Moved the ARM templates to separate files, however it is also possible to include the template in the same `azurerm.rb` file